### PR TITLE
fix: vatsim events max fields

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 Update <small>_ January 2024</small>
 
+- fix: vatsim events max fields (18/01/2024)
 - fix: user and mod log exclude id's (18/01/2024)
 - feat: New FBW Utils and Moderation bot (08/01/2024)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 Update <small>_ January 2024</small>
 
-- fix: vatsim events max fields (18/01/2024)
+- fix: vatsim events max fields (20/01/2024)
 - fix: user and mod log exclude id's (18/01/2024)
 - feat: New FBW Utils and Moderation bot (08/01/2024)

--- a/src/commands/utils/vatsim/functions/vatsimEvents.ts
+++ b/src/commands/utils/vatsim/functions/vatsimEvents.ts
@@ -22,7 +22,7 @@ export async function handleVatsimEvents(interaction: ChatInputCommandInteractio
             .then((res) => res.json())
             .then((res) => res.data)
             .then((res) => res.filter((event: { type: string; }) => event.type === 'Event'))
-            .then((res) => res.slice(0, 6));
+            .then((res) => res.slice(0, 5));
 
         const fields: EmbedField[] = eventsList.map((event: any) => {
             // eslint-disable-next-line camelcase

--- a/src/events/contextInteractionHandler.ts
+++ b/src/events/contextInteractionHandler.ts
@@ -1,4 +1,4 @@
-import { Color, ContextMenuCommand, event, Events, Reply } from '../lib';
+import { Color, ContextMenuCommand, event, Events, makeEmbed, Reply } from '../lib';
 import contextArray from '../commands/context';
 
 const contextMap = new Map<string, ContextMenuCommand>(
@@ -30,7 +30,15 @@ export default event(Events.InteractionCreate, async ({ log, client }, interacti
 
         await context.callback({ client, log, interaction });
     } catch (error) {
+        const errorEmbed = makeEmbed({
+            title: 'An error occurred while executing this context command.',
+            description: `${error}`,
+            color: Color.Error,
+        });
+
         log('[Context Error]', error);
+
+        await interaction.followUp({ embeds: [errorEmbed] });
 
         if (interaction.deferred || interaction.replied) {
             log('Interaction was already replied to or deferred, ignoring');

--- a/src/events/slashCommandHandler.ts
+++ b/src/events/slashCommandHandler.ts
@@ -1,4 +1,4 @@
-import { Color, SlashCommand, event, Events, Reply } from '../lib';
+import { Color, SlashCommand, event, Events, Reply, makeEmbed } from '../lib';
 import commandArray from '../commands';
 
 /* eslint-disable no-underscore-dangle */
@@ -58,7 +58,15 @@ export default event(Events.InteractionCreate, async ({ log, client }, interacti
 
         await command.callback({ client, log, interaction });
     } catch (error) {
+        const errorEmbed = makeEmbed({
+            title: 'An error occurred while executing this command.',
+            description: `${error}`,
+            color: Color.Error,
+        });
+
         log('[Command Error]', error);
+
+        await interaction.followUp({ embeds: [errorEmbed] });
 
         if (interaction.deferred || interaction.replied) {
             log('Interaction was already replied to or deferred, ignoring');


### PR DESCRIPTION
<!-- ## Title -->

<!-- Please use the appropriate prefix in your PR title:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Formatting, missing semi-colons, white-space, etc
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests
- chore: Maintain. Changes to the build process or auxiliary tools/libraries/documentation -->

## Description

Limits the amount of fetched Vatsim events to 5 instead of 6. We can now only ever populate 25 fields in this command, rectifying the error

Also adds an error embed to the command handlers to make it more clear on what went wrong (this isn't specific to the vatsim events command) as an example using this command:

![image](https://github.com/flybywiresim/discord-bot-utils/assets/67422707/798a7535-0db9-4f7d-913c-2642af1e6a7d)
 
The application is left thinking, as the error is outside of the command, but in the handler itself. Other commands will continue to run and the `/vatsim events` command would time out after 15 minutes as per Discord guidelines.

<!-- Give a description about what you have added/changed, what it does, and what the command/alias is. -->

## Test Results

![image](https://github.com/flybywiresim/discord-bot-utils/assets/67422707/33290a00-3b03-47a9-8426-f63efb3030a6)

<!-- Attach a screenshot of your command from your test bot. This will help us speed up the process of reviewing the PR. (If you update your command, while the PR is open, update the screenshot). -->

## Discord Username

benw8484

<!-- Add your discord username, including the number to the bottom of the PR message. This will help us get in contact if we need to. -->
