### PR TITLE
fix: ScamLog - Ignore messages entirely unless it has everyone

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ January 2024</small>
 
+- fix: ScamLog - Ignore messages entirely unless it has everyone (28/01/2024)
 - fix: ignore Dyno bot (27/01/2024)
 - fix: use - instead of _ in command names (27/01/2024)
 - feat: auto-generation of the command table (24/01/2024)
@@ -10,3 +11,4 @@ Update <small>_ January 2024</small>
 - fix: vatsim events max fields (20/01/2024)
 - fix: user and mod log exclude id's (18/01/2024)
 - feat: New FBW Utils and Moderation bot (08/01/2024)
+

--- a/src/events/logging/scamLogs.ts
+++ b/src/events/logging/scamLogs.ts
@@ -47,14 +47,14 @@ export default event(Events.MessageCreate, async ({ log }, msg) => {
         return;
     }
 
-    const scamReportLogs = msg.guild.channels.resolve(constantsConfig.channels.SCAM_REPORT_LOGS) as TextChannel | null;
-
-    if (!conn && scamReportLogs) {
-        await scamReportLogs.send({ embeds: [noConnEmbed] });
-        return;
-    }
-
     if (scamReportLogs && msg.content.toLowerCase().includes('@everyone') && !msg.author.bot) {
+        const scamReportLogs = msg.guild.channels.resolve(constantsConfig.channels.SCAM_REPORT_LOGS) as TextChannel | null;
+
+        if (!conn && scamReportLogs) {
+            await scamReportLogs.send({ embeds: [noConnEmbed] });
+            return;
+        }
+
         if (!(msg.channel instanceof DMChannel)) {
             let hasRole = false;
             try {

--- a/src/events/logging/scamLogs.ts
+++ b/src/events/logging/scamLogs.ts
@@ -40,16 +40,14 @@ const deleteFailed = makeEmbed({
 });
 
 export default event(Events.MessageCreate, async ({ log }, msg) => {
-    const conn = getConn();
-
     if (msg.guild === null) {
         // DM's
         return;
     }
 
+    const scamReportLogs = msg.guild.channels.resolve(constantsConfig.channels.SCAM_REPORT_LOGS) as TextChannel | null;
     if (scamReportLogs && msg.content.toLowerCase().includes('@everyone') && !msg.author.bot) {
-        const scamReportLogs = msg.guild.channels.resolve(constantsConfig.channels.SCAM_REPORT_LOGS) as TextChannel | null;
-
+        const conn = getConn();
         if (!conn && scamReportLogs) {
             await scamReportLogs.send({ embeds: [noConnEmbed] });
             return;


### PR DESCRIPTION
# fix: ScamLog - Ignore messages entirely unless it has everyone

## Description

When the DB connection is down, the bot would send a scamlog error for every message instead of only for those with @everyone

## Discord Username

straks