### PR TITLE
fix: clearer logging for the role assignment handler

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ January 2024</small>
 
+- fix: clearer logging for the role assignment handler (28/01/2024)
 - fix: command names (28/01/2024)
 - fix: ignore Dyno bot (27/01/2024)
 - fix: use - instead of _ in command names (27/01/2024)

--- a/src/events/roleAssignmentHandler.ts
+++ b/src/events/roleAssignmentHandler.ts
@@ -9,12 +9,17 @@ export default event(Events.InteractionCreate, async ({ log }, interaction) => {
     try {
         const roleButtonCustomIds = constantsConfig.roleAssignmentIds.flatMap((group) => group.roles.map((role) => role.id));
 
-        const { customId } = interaction;
+        const { customId, component, user } = interaction;
 
         // Check if the pressed button's custom ID is in the array of role-related custom IDs
         if (!roleButtonCustomIds.includes(customId)) {
-            Logger.info('Role Assignment: Custom ID not matched');
-            // If the custom ID doesn't match any role-related buttons, return early
+            const buttonLabel = component?.label;
+
+            if (buttonLabel) {
+                Logger.info(`Role Assignment: Custom ID not matched. Custom ID: ${customId}, Label: ${buttonLabel}, User: ${user.tag}, User ID: ${user.id}`);
+            } else {
+                Logger.info(`Role Assignment: Custom ID not matched. Custom ID: ${customId}, Label: null, User: ${user.tag}, User ID: ${user.id}`);
+            }
             return;
         }
 


### PR DESCRIPTION
<!-- ## Title -->

<!-- Please use the appropriate prefix in your PR title:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Formatting, missing semi-colons, white-space, etc
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests
- chore: Maintain. Changes to the build process or auxiliary tools/libraries/documentation -->

## Description

Gives clearer logging in the role assignment handler when the button ID doesn't match. It shows us which button was pressed and by who.

In the future, I may make this a generic button press handler, and then call logic based on what buttons are pressed. This would save us from creating more event listeners every time we need to watch for buttons.

<!-- Give a description about what you have added/changed, what it does, and what the command/alias is. -->

## Test Results

![image](https://github.com/flybywiresim/discord-bot-utils/assets/67422707/aaaf6645-2a26-444e-8b15-44a5ad8d47d4)

<!-- Attach a screenshot of your command from your test bot. This will help us speed up the process of reviewing the PR. (If you update your command, while the PR is open, update the screenshot). -->

## Discord Username

benw8484

<!-- Add your discord username, including the number to the bottom of the PR message. This will help us get in contact if we need to. -->
