### PR TITLE
fix: scam logs crash on message over 1024 characters

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ February 2024</small>
 
+- fix: scamlog crash (11/02/2024)
 - fix: message edit and delete crash (01/02/2024)
 - feat: add heartbeat mechanism for monitoring (01/02/2024)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Update <small>_ February 2024</small>
 
-- fix: scamlog crash (11/02/2024)
+- fix: scamlog crash (16/02/2024)
 - fix: defer replies for metar, station and taf commands (03/02/2024)
 - fix: message edit and delete crash (01/02/2024)
 - feat: add heartbeat mechanism for monitoring (01/02/2024)

--- a/src/events/logging/scamLogs.ts
+++ b/src/events/logging/scamLogs.ts
@@ -1,16 +1,6 @@
 import { codeBlock, Colors, DMChannel, TextChannel } from 'discord.js';
 import mongoose from 'mongoose';
-import {
-    constantsConfig,
-    makeEmbed,
-    makeLines,
-    event,
-    Events,
-    getConn,
-    Infraction,
-    Logger,
-    imageBaseUrl,
-} from '../../lib';
+import { constantsConfig, makeEmbed, makeLines, event, Events, getConn, Infraction, Logger, imageBaseUrl } from '../../lib';
 
 const excludedRoles = [
     constantsConfig.roles.ADMIN_TEAM,
@@ -53,6 +43,17 @@ export default event(Events.MessageCreate, async ({ log }, msg) => {
             return;
         }
 
+        const MAX_MESSAGE_LENGTH = 1024;
+
+        let messageContent = msg.content.toString();
+
+        let messageContentFieldTitle = 'Message Content:';
+
+        if (messageContent.length > MAX_MESSAGE_LENGTH) {
+            messageContent = `${msg.content.slice(0, MAX_MESSAGE_LENGTH - 11)}...`;
+            messageContentFieldTitle = 'Message Content (truncated):';
+        }
+
         if (!(msg.channel instanceof DMChannel)) {
             let hasRole = false;
             try {
@@ -85,8 +86,8 @@ export default event(Events.MessageCreate, async ({ log }, msg) => {
                             value: `${msg.channel}`,
                         },
                         {
-                            name: 'Message Content:',
-                            value: codeBlock(msg.content.toString()),
+                            name: messageContentFieldTitle,
+                            value: codeBlock(messageContent),
                         },
                     ],
                 });
@@ -119,8 +120,8 @@ export default event(Events.MessageCreate, async ({ log }, msg) => {
                         value: `${msg.channel}`,
                     },
                     {
-                        name: 'Message Content:',
-                        value: codeBlock(msg.content.toString()),
+                        name: messageContentFieldTitle,
+                        value: codeBlock(messageContent),
                     },
                 ],
             });


### PR DESCRIPTION
<!-- ## Title -->

<!-- Please use the appropriate prefix in your PR title:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Formatting, missing semi-colons, white-space, etc
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests
- chore: Maintain. Changes to the build process or auxiliary tools/libraries/documentation -->

## Description

Fixes #29

This PR fixes a crash when a message containing `@everyone` has over 1024 characters. This is the same issue as in PR #25

<!-- Give a description about what you have added/changed, what it does, and what the command/alias is. -->

## Test Results

![image](https://github.com/flybywiresim/discord-bot-utils/assets/67422707/7a44fc4f-f626-4c5f-b331-13b5e83dead1)
![image](https://github.com/flybywiresim/discord-bot-utils/assets/67422707/69525135-8b35-433a-a4c8-86b9971704e1)

<!-- Attach a screenshot of your command from your test bot. This will help us speed up the process of reviewing the PR. (If you update your command, while the PR is open, update the screenshot). -->

## Discord Username

benw8484

<!-- Add your discord username, including the number to the bottom of the PR message. This will help us get in contact if we need to. -->
