### PR TITLE
fix: multiple plus symbols in zulu

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ March 2024</small>
 
+- fix: multiple plus symbols in zulu command (18/03/2024)
 - feat: add infractions counts to buttons in list infractions command (18/03/2024)
 
 Update <small>_ February 2024</small>

--- a/src/commands/utils/zulu.ts
+++ b/src/commands/utils/zulu.ts
@@ -17,9 +17,11 @@ const data = slashCommandStructure({
 const dateFormat = 'HH:mm (LT)';
 
 export default slashCommand(data, async ({ interaction }) => {
-    const utcOffset = interaction.options.getString('offset') ?? '0';
+    let utcOffset = interaction.options.getString('offset') ?? '0';
 
-    const numericOffset = Number(utcOffset);
+    utcOffset = utcOffset.replace(/^[+-]+/, (match) => match[0]);
+    const numericOffset = parseInt(utcOffset);
+    const sign = utcOffset.startsWith('-') ? '-' : '+';
 
     if (Number.isNaN(numericOffset)
         || numericOffset < -12
@@ -35,5 +37,7 @@ export default slashCommand(data, async ({ interaction }) => {
         return interaction.reply({ embeds: [invalidEmbed], ephemeral: true });
     }
 
-    return interaction.reply({ content: `It is ${moment().utc().add(utcOffset, 'hours').format(dateFormat)} in that timezone (UTC${numericOffset >= 0 ? '+' : ''}${utcOffset}).` });
+    const formattedOffset = `${sign}${Math.abs(numericOffset)}`;
+
+    return interaction.reply({ content: `It is ${moment().utc().add(utcOffset, 'hours').format(dateFormat)} in that timezone (UTC${formattedOffset}).` });
 });


### PR DESCRIPTION
<!-- ## Title -->

<!-- Please use the appropriate prefix in your PR title:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Formatting, missing semi-colons, white-space, etc
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests
- chore: Maintain. Changes to the build process or auxiliary tools/libraries/documentation -->

## Description

Fixes #18 

Fixes multiple plus symbols in the zulu command output. As well as  a few other bugs like erroring when more than one + or - is used.

It will just take the first symbol used. So if you input -+2, it will be treated as -2. If you input +-2, it will be treated as +2.

<!-- Give a description about what you have added/changed, what it does, and what the command/alias is. -->

## Test Results

Results using a varied amount of inputs.

++2, +2, 2, -0, 0, ------2 etc.

![image](https://github.com/flybywiresim/discord-bot-utils/assets/67422707/5035958e-38ab-4b34-b0ad-da4f50e17441)

<!-- Attach a screenshot of your command from your test bot. This will help us speed up the process of reviewing the PR. (If you update your command, while the PR is open, update the screenshot). -->

## Discord Username

benw8484

<!-- Add your discord username, including the number to the bottom of the PR message. This will help us get in contact if we need to. -->
