### PR TITLE
chore: fix eol issues on Windows

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,5 @@
 [*]
 charset = utf-8
-end_of_line = lf
 indent_size = 4
 indent_style = space
 insert_final_newline = true

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,7 @@
     ],
     // overrides airbnb, use sparingly
     "rules": {
+        "linebreak-style": "off",
         "object-curly-newline": ["error", { "multiline": true }],
         "max-len": "off",
         "spaced-comment": "off"

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Automatically normalize text files.
+* text=auto
+
+# Ensure all shell files use LF.
+*.sh text eol=lf

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+Update <small>_ May 2024</small>
+
+- chore: fix eol issues on Windows
+
 Update <small>_ April 2024</small>
 
 - fix: clarify errors in timeout command (30/04/2024)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Update <small>_ May 2024</small>
 
-- chore: fix eol issues on Windows
+- chore: fix eol issues on Windows (17/05/2024)
 
 Update <small>_ April 2024</small>
 


### PR DESCRIPTION
<!-- ## Title -->

<!-- Please use the appropriate prefix in your PR title:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Formatting, missing semi-colons, white-space, etc
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests
- chore: Maintain. Changes to the build process or auxiliary tools/libraries/documentation -->

## Description
Enforcing eol through eslint causes issues for Windows users. This is because git will convert LF files to CRLF by default on Windows.

This PR fixes that by using git to manage eol automatically. 

More information: https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings

<!-- Give a description about what you have added/changed, what it does, and what the command/alias is. -->

## Test Results
n/a

<!-- Attach a screenshot of your command from your test bot. This will help us speed up the process of reviewing the PR. (If you update your command, while the PR is open, update the screenshot). -->

## Discord Username
examplewastaken

<!-- Add your discord username, including the number to the bottom of the PR message. This will help us get in contact if we need to. -->
