### PR TITLE
fix: keep footer on embed expire

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Update <small>_ May 2024</small>
 
-- fix: keep footer on embed expire
+- fix: keep footer on embed expire (29/05/2024)
 - feat: /clear-messages command (29/05/2024)
 - refactor: improve and simplify embed pagination (29/05/2024)
 - feat: button handler (27/05/2024)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ May 2024</small>
 
+- fix: keep footer on embed expire
 - feat: /clear-messages command (29/05/2024)
 - refactor: improve and simplify embed pagination (29/05/2024)
 - feat: button handler (27/05/2024)

--- a/src/commands/moderation/infractions/functions/listInfractions.ts
+++ b/src/commands/moderation/infractions/functions/listInfractions.ts
@@ -348,7 +348,7 @@ export async function handleListInfraction(interaction: CommandInteraction, user
                     inline: true,
                 },
             ],
-            footer: { text: 'The buttons will expire in two minutes from command execution.' },
+            footer: { text: 'This embed will expire in two minutes from command execution.' },
         });
 
         //Collect embeds and send with the paginator

--- a/src/lib/genericEmbedPagination.ts
+++ b/src/lib/genericEmbedPagination.ts
@@ -25,7 +25,7 @@ export async function createPaginatedEmbedHandler(initialInteraction: CommandInt
     }
 
     const filter = (buttonInteraction: Interaction) => initialInteraction.user.id === buttonInteraction.user.id;
-    const collector = message.createMessageComponentCollector({ filter, componentType: ComponentType.Button, time: 5_000 });
+    const collector = message.createMessageComponentCollector({ filter, componentType: ComponentType.Button, time: 120_000 });
 
     collector.on('collect', async (collectedInteraction: ButtonInteraction) => {
         await collectedInteraction.deferUpdate();
@@ -51,7 +51,7 @@ export async function createPaginatedEmbedHandler(initialInteraction: CommandInt
 
     function handleEmbedExpire() {
         const embed = embeds[currentPage];
-        initialInteraction.editReply({ embeds: [embed.setFooter({text: `${embed.data.footer ? embed.data.footer.text + ' - ' : ''} This embed has expired.`})], components: [] });
+        initialInteraction.editReply({ embeds: [embed.setFooter({ text: `${embed.data.footer ? `${embed.data.footer.text} - ` : ''} This embed has expired.` })], components: [] });
     }
 
     function setButtonDisabledStates() {

--- a/src/lib/genericEmbedPagination.ts
+++ b/src/lib/genericEmbedPagination.ts
@@ -28,7 +28,7 @@ export async function createPaginatedEmbedHandler(initialInteraction: CommandInt
     const collector = message.createMessageComponentCollector({ filter, componentType: ComponentType.Button, time: 5_000 });
 
     collector.on('collect', async (collectedInteraction: ButtonInteraction) => {
-        collectedInteraction.deferUpdate();
+        await collectedInteraction.deferUpdate();
 
         if (collectedInteraction.customId === 'pagination_nextPage') {
             currentPage++;

--- a/src/lib/genericEmbedPagination.ts
+++ b/src/lib/genericEmbedPagination.ts
@@ -17,7 +17,7 @@ export async function createPaginatedEmbedHandler(initialInteraction: CommandInt
 
     const buttonRow = new ActionRowBuilder<ButtonBuilder>().addComponents(prevButton, nextButton);
 
-    let message: Message<boolean> | InteractionResponse<boolean>;
+    let message: Message | InteractionResponse;
     if (initialInteraction.deferred || initialInteraction.replied) {
         message = await initialInteraction.editReply({ embeds: [embeds[currentPage]], components: [buttonRow] });
     } else {

--- a/src/lib/genericEmbedPagination.ts
+++ b/src/lib/genericEmbedPagination.ts
@@ -25,7 +25,7 @@ export async function createPaginatedEmbedHandler(initialInteraction: CommandInt
     }
 
     const filter = (buttonInteraction: Interaction) => initialInteraction.user.id === buttonInteraction.user.id;
-    const collector = message.createMessageComponentCollector({ filter, componentType: ComponentType.Button, time: 120_000 });
+    const collector = message.createMessageComponentCollector({ filter, componentType: ComponentType.Button, time: 5_000 });
 
     collector.on('collect', async (collectedInteraction: ButtonInteraction) => {
         collectedInteraction.deferUpdate();
@@ -50,7 +50,8 @@ export async function createPaginatedEmbedHandler(initialInteraction: CommandInt
     }
 
     function handleEmbedExpire() {
-        initialInteraction.editReply({ embeds: [embeds[currentPage].setFooter({ text: 'This embed has expired.' })], components: [] });
+        const embed = embeds[currentPage];
+        initialInteraction.editReply({ embeds: [embed.setFooter({text: `${embed.data.footer ? embed.data.footer.text + ' - ' : ''} This embed has expired.`})], components: [] });
     }
 
     function setButtonDisabledStates() {

--- a/src/lib/genericEmbedPagination.ts
+++ b/src/lib/genericEmbedPagination.ts
@@ -51,7 +51,7 @@ export async function createPaginatedEmbedHandler(initialInteraction: CommandInt
 
     function handleEmbedExpire() {
         const embed = embeds[currentPage];
-        initialInteraction.editReply({ embeds: [embed.setFooter({ text: `${embed.data.footer ? `${embed.data.footer.text} - ` : ''} This embed has expired.` })], components: [] });
+        initialInteraction.editReply({ embeds: [embed.setFooter({ text: `${embed.data.footer ? `${embed.data.footer.text} - ` : ''}This embed has expired.` })], components: [] });
     }
 
     function setButtonDisabledStates() {

--- a/src/lib/infractionEmbedPagination.ts
+++ b/src/lib/infractionEmbedPagination.ts
@@ -85,6 +85,6 @@ export async function createPaginatedInfractionEmbedHandler(initialInteraction: 
 
     function handleEmbedExpire() {
         const embed = embeds[currentPage];
-        initialInteraction.editReply({ embeds: [embed.setFooter({ text: `${embed.data.footer ? `${embed.data.footer.text} - ` : ''} This embed has expired.` })], components: [] });
+        initialInteraction.editReply({ embeds: [embed.setFooter({ text: `${embed.data.footer ? `${embed.data.footer.text} - ` : ''}This embed has expired.` })], components: [] });
     }
 }

--- a/src/lib/infractionEmbedPagination.ts
+++ b/src/lib/infractionEmbedPagination.ts
@@ -43,7 +43,7 @@ export async function createPaginatedInfractionEmbedHandler(initialInteraction: 
     const message = await initialInteraction.followUp({ embeds: [embeds[currentPage]], components: [buttonRow1, buttonRow2] });
 
     const filter = (interaction: Interaction) => interaction.user.id === user;
-    const collector = message.createMessageComponentCollector({ filter, time: 5_000 });
+    const collector = message.createMessageComponentCollector({ filter, time: 120_000 });
 
     collector.on('collect', async (collectedInteraction: ButtonInteraction) => {
         await collectedInteraction.deferUpdate();
@@ -85,6 +85,6 @@ export async function createPaginatedInfractionEmbedHandler(initialInteraction: 
 
     function handleEmbedExpire() {
         const embed = embeds[currentPage];
-        initialInteraction.editReply({ embeds: [embed.setFooter({text: `${embed.data.footer ? embed.data.footer.text + ' - ' : ''} This embed has expired.`})], components: [] });
+        initialInteraction.editReply({ embeds: [embed.setFooter({ text: `${embed.data.footer ? `${embed.data.footer.text} - ` : ''} This embed has expired.` })], components: [] });
     }
 }

--- a/src/lib/infractionEmbedPagination.ts
+++ b/src/lib/infractionEmbedPagination.ts
@@ -46,7 +46,7 @@ export async function createPaginatedInfractionEmbedHandler(initialInteraction: 
     const collector = message.createMessageComponentCollector({ filter, time: 5_000 });
 
     collector.on('collect', async (collectedInteraction: ButtonInteraction) => {
-        collectedInteraction.deferUpdate();
+        await collectedInteraction.deferUpdate();
 
         if (collectedInteraction.customId === 'infractions_about') {
             currentPage = 0;

--- a/src/lib/infractionEmbedPagination.ts
+++ b/src/lib/infractionEmbedPagination.ts
@@ -43,7 +43,7 @@ export async function createPaginatedInfractionEmbedHandler(initialInteraction: 
     const message = await initialInteraction.followUp({ embeds: [embeds[currentPage]], components: [buttonRow1, buttonRow2] });
 
     const filter = (interaction: Interaction) => interaction.user.id === user;
-    const collector = message.createMessageComponentCollector({ filter, time: 120000 });
+    const collector = message.createMessageComponentCollector({ filter, time: 5_000 });
 
     collector.on('collect', async (collectedInteraction: ButtonInteraction) => {
         collectedInteraction.deferUpdate();
@@ -84,6 +84,7 @@ export async function createPaginatedInfractionEmbedHandler(initialInteraction: 
     }
 
     function handleEmbedExpire() {
-        initialInteraction.editReply({ embeds: [embeds[currentPage].setFooter({ text: 'This embed has expired.' })], components: [] });
+        const embed = embeds[currentPage];
+        initialInteraction.editReply({ embeds: [embed.setFooter({text: `${embed.data.footer ? embed.data.footer.text + ' - ' : ''} This embed has expired.`})], components: [] });
     }
 }


### PR DESCRIPTION
<!-- ## Title -->

<!-- Please use the appropriate prefix in your PR title:

- feat: A new feature
- fix: A bug fix
- docs: Documentation only changes
- style: Formatting, missing semi-colons, white-space, etc
- refactor: A code change that neither fixes a bug nor adds a feature
- perf: A code change that improves performance
- test: Adding missing tests
- chore: Maintain. Changes to the build process or auxiliary tools/libraries/documentation -->

## Description
Small fix too keep the footer (if there is one) when a paginated embed expires.
<!-- Give a description about what you have added/changed, what it does, and what the command/alias is. -->

## Test Results

![image](https://github.com/flybywiresim/discord-bot-utils/assets/58574351/c125012d-8ac2-45cf-831d-28fc2cded67c)


## Discord Username

<!-- Add your discord username, including the number to the bottom of the PR message. This will help us get in contact if we need to. -->
