### PR TITLE
feat: add optional description to /locate panels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,8 @@ MONGODB_DATABASE=fbw
 MONGODB_URL=mongodb://admin:1234@localhost:27017/fbw?authSource=admin
 
 # Below are examples of what this .env entry could be.
-IMAGE_BASE_URL=https://assets.discord.flybywirecdn.com/assets/images
-IMAGE_BASE_URL=https://assets-staging.discord.flybywirecdn.com/assets/images
+IMAGE_BASE_URL=https://assets.discord.flybywirecdn.com/utils/assets/images
+IMAGE_BASE_URL=https://assets-staging.discord.flybywirecdn.com/utils/assets/images/
 IMAGE_BASE_URL=YourOwnLocationForLocalDev
 
 # You will need the following to upload to cloudflare

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+Update <small>_ June 2024</small>
+
+- feat: add optional description to `/locate` panels.
+
 Update <small>_ May 2024</small>
 
 - fix: keep footer on embed expire (29/05/2024)

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Update <small>_ June 2024</small>
 
-- feat: add optional description to `/locate` panels.
+- feat: add optional description to `/locate` panels. (17/06/2024)
 
 Update <small>_ May 2024</small>
 

--- a/src/commands/utils/locate/functions/handleCommand.ts
+++ b/src/commands/utils/locate/functions/handleCommand.ts
@@ -23,6 +23,7 @@ const locateEmbed = (panel: Panel) => makeEmbed({
         `* [${panel.name} Documentation](${panel.docsUrl})`,
         `* [Flight Deck Overview](${panel.flightDeckUrl})`,
     ]),
+    fields: panel.description ? [panel.description] : [],
     image: { url: panel.imageUrl },
     footer: { text: 'Tip: Click the image to view in full size' },
 });
@@ -39,6 +40,8 @@ export async function handleCommand(interaction: ChatInputCommandInteraction<'ca
         return interaction.editReply({ embeds: [invalidTargetEmbed] });
     }
     const panel = panelMap.get(cleanTarget)!;
+
+    console.log(panel.imageUrl);
 
     return interaction.editReply({ embeds: [locateEmbed(panel)] });
 }

--- a/src/commands/utils/locate/functions/handleCommand.ts
+++ b/src/commands/utils/locate/functions/handleCommand.ts
@@ -41,7 +41,5 @@ export async function handleCommand(interaction: ChatInputCommandInteraction<'ca
     }
     const panel = panelMap.get(cleanTarget)!;
 
-    console.log(panel.imageUrl);
-
     return interaction.editReply({ embeds: [locateEmbed(panel)] });
 }

--- a/src/commands/utils/locate/panels/a32nx/overhead.ts
+++ b/src/commands/utils/locate/panels/a32nx/overhead.ts
@@ -1,3 +1,4 @@
+import { makeLines } from '../../../../../lib';
 import { LOCATE_DOCS_BASE_URLS, LOCATE_IMAGE_BASE_URLS } from '../../base-urls';
 import { Panel } from '../panel';
 
@@ -142,6 +143,14 @@ export const fltCtlPanel: Panel = {
 export const adirsPanel: Panel = {
     name: 'ADIRS Panel',
     title: 'FlyByWire A32NX | ADIRS Panel',
+    description: {
+        name: 'Aligning the ADIRSs',
+        value: makeLines([
+            'On the overhead panel you will see the three switches under \'ADIRS\'. Turn these three to the \'NAV\' position. It takes several minutes for the ADIRUs to align.',
+            'You can check how long you have to wait by looking at the align time on your Upper Ecam.',
+        ]),
+        inline: false,
+    },
     docsUrl: `${OVHD_DOCS_BASE_URL}/adirs/`,
     flightDeckUrl: LOCATE_DOCS_BASE_URLS.a32nx.flightdeck,
     imageUrl: `${OVHD_IMAGE_BASE_URL}/adirs.png`,

--- a/src/commands/utils/locate/panels/panel.ts
+++ b/src/commands/utils/locate/panels/panel.ts
@@ -1,4 +1,4 @@
-import { EmbedField } from "discord.js";
+import { EmbedField } from 'discord.js';
 
 export interface Panel {
     /**

--- a/src/commands/utils/locate/panels/panel.ts
+++ b/src/commands/utils/locate/panels/panel.ts
@@ -1,3 +1,5 @@
+import { EmbedField } from "discord.js";
+
 export interface Panel {
     /**
      * The name of the Panel. This should be usable in sentences.
@@ -8,6 +10,11 @@ export interface Panel {
      * The title of the Panel. -> Used as the embed title.
      */
     title: string;
+
+    /**
+     * Optional description for a panel such as instructions on aligning the ADIRSs.
+     */
+    description?: EmbedField;
 
     /**
      * The URL to the relevant documentation.


### PR DESCRIPTION
## Description
Adds an optional embed field to panels of the `/locate` command to be used for short support instructions.

<!-- Give a description about what you have added/changed, what it does, and what the command/alias is. -->

## Test Results
Command with description:
<img height="400" alt="Screenshot 2024-06-17 at 18 07 50" src="https://github.com/flybywiresim/discord-bot-utils/assets/58574351/ee9435dd-e895-412f-829d-753bb875abef">

Command without description:
<img height="300" alt="Screenshot 2024-06-17 at 18 20 30" src="https://github.com/flybywiresim/discord-bot-utils/assets/58574351/0c11985d-4de4-4395-9d80-9a64e64bf20f">

<!-- Attach a screenshot of your command from your test bot. This will help us speed up the process of reviewing the PR. (If you update your command, while the PR is open, update the screenshot). -->

## Discord Username
`examplewastaken`
<!-- Add your discord username, including the number to the bottom of the PR message. This will help us get in contact if we need to. -->
