### PR TITLE
fix: corrected typo in simbrief-data support-request embed and also correction in contributing.md

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+Update <small>_ July 2024</small>
+
+- fix: corrected typo in the embed for simbrief-data support-request (16/07/2024)
+- docs: updated the Ground Rules on the Contributing guide page (16/07/2024)
+
 Update <small>_ May 2024</small>
 
 - fix: keep footer on embed expire (29/05/2024)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Please help other contributors to the project wherever you can, as people all st
 
 To ensure that commands are written professionally and clearly, please follow the guide below:
 
-- Use the proper name for third party services. For example: simBrief and not SimBrief.
+- Use the proper name for third party services. For example: SimBrief and not simBrief.
 - If you are using images within the command, please ensure that they are clear and easy to understand.
 - Refrain from using exclamation points unless it is a warning.
 - Ensure that the contents of the command are correct. If you are unsure if something is correct please speak to any bot developer, and they will be able to verify anything.

--- a/src/commands/utils/simbriefData.ts
+++ b/src/commands/utils/simbriefData.ts
@@ -33,7 +33,7 @@ const simbriefdatarequestEmbed = makeEmbed({
     title: 'FlyByWire Support | SimBrief Data Request',
     description: makeLines([
         'To evaluate your problem we kindly ask you to enter the following bot command into a new message.',
-        '```/simbrief_data retrieve```',
+        '```/simbrief-data retrieve```',
         'Enter your `pilotId` with your simbrief pilotId or userName (as set in the EFB settings). The Bot will read your last generated flight plan and display some details about it including the route.',
         '',
         '**Privacy notice**: If you share your pilotId or username it is possible to read your pilot name from the API the bot uses. This pilot name is by default your real name, but you can change it in the flight edit screen or your user profile in SimBrief. No data is stored by FlyByWire when using the command.',


### PR DESCRIPTION
## Description

Small PR to correct two things
-  typo in the embed for simbrief-data support-request - this was telling users to input `simbrief_data retrieve` rather than what the actual command is, `simbrief-data retrieve`.
- In contributing.md the Ground Rules give an example of naming things correctly. It still makes reference to ensuring simBrief is used instead of SimBrief, however SimBrief is now correct. Have swapped these around. 

Change log entries added.

## Test Results

I have not tested this as I do not have a Bot test environment setup, however the only change impacting the bot directly is a single character and the second commit is for a GitHub page.

## Discord Username
jason_91
