### PR TITLE
fix: temporarily pin TypeScript to v5.4.x

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Update <small>_ August 2024</small>
 
-- fix: temporarily pin typescript version to v5.4.x (see https://github.com/flybywiresim/discord-bot-utils/issues/78) (06/10/2024)
+- fix: temporarily pin typescript version to v5.4.x (see https://github.com/flybywiresim/discord-bot-utils/issues/78) (07/10/2024)
 
 Update <small>_ July 2024</small>
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+Update <small>_ August 2024</small>
+
+- fix: temporarily pin typescript version to v5.4.x (see https://github.com/flybywiresim/discord-bot-utils/issues/78) (06/10/2024)
+
 Update <small>_ July 2024</small>
 
 - fix: resolve security vulnerabilities in 3rd-party packages (27/07/2024)

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "eslint": "^7.29.0",
         "nodemon": "^3.0.2",
         "ts-node": "^10.4.0",
-        "typescript": "^5.0.3"
+        "typescript": "~5.4.5"
       },
       "engines": {
         "node": "18.x"
@@ -7362,10 +7362,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint": "^7.29.0",
     "nodemon": "^3.0.2",
     "ts-node": "^10.4.0",
-    "typescript": "^5.0.3"
+    "typescript": "~5.4.5"
   },
   "engines": {
     "node": "18.x"


### PR DESCRIPTION
## Description
Due to a breaking bug fix in TS `v5.5` our build fails with that minor version. To prevent accidental updates until the issue is resolved, this PR pins TS to the `v5.4.x` minor release.

For more information see #78 

## Test Results

See build workflow
