### PR TITLE
Fix: Changing A32NX Releases to Aircraft Releases in Role assignment

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ October 2024</small>
 
+- fix: Changing A32NX Releases to Aircraft Releases in Role assignment (30/10/2024)
 - fix: Bugs with permissions causing crash during startup or prefix command handling (30/10/2024)
 - feat: Prefix Command Management (28/10/2024)
 - fix: role assignment typo for server announcements (22/10/2024)

--- a/config/production.json
+++ b/config/production.json
@@ -54,8 +54,8 @@
           "label": "Server Announcements"
         },
         {
-          "id": "A32NX_RELEASES",
-          "label": "A32NX Releases"
+          "id": "AIRCRAFT_RELEASES",
+          "label": "Aircraft Releases"
         },
         {
           "id": "PROGRESS",
@@ -94,7 +94,7 @@
     ]
   },
   "roles": {
-    "A32NX_RELEASES": "748938423045193728",
+    "AIRCRAFT_RELEASES": "748938423045193728",
     "ADMIN_TEAM": "738864824305319936",
     "BOT_DEVELOPER": "768888763929591818",
     "COMMUNITY_SUPPORT": "870394933926830100",

--- a/config/staging.json
+++ b/config/staging.json
@@ -59,6 +59,10 @@
           "label": "Server Announcements"
         },
         {
+          "id": "AIRCRAFT_RELEASES",
+          "label": "Aircraft Releases"
+        },
+        {
           "id": "PROGRESS_ANNOUNCEMENT",
           "label": "Progress Announcements"
         }
@@ -91,6 +95,7 @@
     ]
   },
   "roles": {
+    "AIRCRAFT_RELEASES": "1301308639453384704",
     "ADMIN_TEAM": "1162821800225419272",
     "BOT_DEVELOPER": "1162822853306101901",
     "COMMUNITY_SUPPORT": "1162822911745347594",


### PR DESCRIPTION


## Discord Username

straks
