### PR TITLE
Fix issue where setting username and avatar triggers rate limit 

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Update <small>_ October 2025</small>
 
+- fix: Username and avatar configuration rate limit fix. These can be set through developer console instead.
 - feat: Logging improvement for clarity
 
 Update <small>_ March 2025</small>

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -1,4 +1,4 @@
-import { ActivityType, TextChannel } from 'discord.js';
+import { TextChannel } from 'discord.js';
 import moment from 'moment';
 import {
     constantsConfig,
@@ -7,7 +7,6 @@ import {
     connect,
     setupScheduler,
     Logger,
-    imageBaseUrl,
     getScheduler,
     setupInMemoryCache,
     loadAllPrefixCommandsToCache,
@@ -28,6 +27,8 @@ export default event(Events.ClientReady, async ({ log }, client) => {
         }
     });
 
+    /**
+    // Disabling as this should be done through the Discord Developer Portal
     // Set username, activity, status and avatar
     if (process.env.NODE_ENV === 'production') {
         Logger.info('Production environment detected, setting username, activity, status and avatar.');
@@ -41,6 +42,7 @@ export default event(Events.ClientReady, async ({ log }, client) => {
             Logger.error('Failed to set username, activity, status and avatar:', error);
         }
     }
+    */
 
     // Deploy commands and contexts
     if (process.env.DEPLOY === 'true') {


### PR DESCRIPTION
## Fix production environment issue where restarts could trigger a rate … limit, invalidating the session

## Description

When the bot restarts a few times in production, we hit a rate limit on the username and avatar API. This then triggers possible failures of posting messages. 

Disabling this functionality as these settings should be possible through the Discord Developer Portal instead.

## Discord Username

straks
