### PR TITLE
fix: Removing Presence intent and scam message detail logging

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Update <small>_ August 2026</small>
 
+- fix: Remove the Presence gateway intent and the status field from whois/User Info (15/08/2026)
+- fix: Stop storing scam-flagged message content in the infractions database (15/08/2026)
 - chore: modernize the stack — move to Node 24, pnpm, ESLint 10, Prettier, obscenity (replacing bad-words) and the global fetch (26/06/2026)
 
 Update <small>_ October 2025</small>

--- a/src/client.ts
+++ b/src/client.ts
@@ -20,7 +20,6 @@ export const client = new Client({
         GatewayIntentBits.MessageContent,
         GatewayIntentBits.GuildMessageReactions,
         GatewayIntentBits.GuildBans,
-        GatewayIntentBits.GuildPresences,
     ],
 });
 

--- a/src/commands/context/user/userInfo.ts
+++ b/src/commands/context/user/userInfo.ts
@@ -9,27 +9,11 @@ const data = contextMenuCommandStructure({
     dm_permission: false,
 });
 
-const beautifiedStatus: { [key: string]: string } = {
-    ONLINE: 'Online',
-    IDLE: 'Idle',
-    DND: 'Do Not Disturb',
-    OFFLINE: 'Offline',
-};
-
 export default contextMenuCommand(data, async ({ interaction }) => {
     const targetMember = interaction.guild?.members.cache.get(interaction.targetId)!;
 
     const filteredRoles = targetMember.roles.cache.filter((role) => role.id !== interaction.guild.id);
     const listedRoles = filteredRoles.sort((a, b) => b.position - a.position).map((role) => role.toString());
-
-    const onlineStatus = beautifiedStatus[targetMember.presence?.status?.toUpperCase() ?? 'OFFLINE'];
-
-    let status;
-    if (targetMember.presence == null) {
-        status = 'Offline';
-    } else {
-        status = onlineStatus;
-    }
 
     const whoisEmbed = makeEmbed({
         author: {
@@ -42,11 +26,6 @@ export default contextMenuCommand(data, async ({ interaction }) => {
             {
                 name: 'Username',
                 value: targetMember.user.tag,
-                inline: true,
-            },
-            {
-                name: 'Status',
-                value: status,
                 inline: true,
             },
             {

--- a/src/commands/moderation/whois.ts
+++ b/src/commands/moderation/whois.ts
@@ -18,27 +18,11 @@ const data = slashCommandStructure({
     ],
 });
 
-const beautifiedStatus: { [key: string]: string } = {
-    ONLINE: 'Online',
-    IDLE: 'Idle',
-    DND: 'Do Not Disturb',
-    OFFLINE: 'Offline',
-};
-
 export default slashCommand(data, async ({ interaction }) => {
     const targetMember = interaction.options.getMember('tag_or_id') ?? interaction.member;
 
     const filteredRoles = targetMember.roles.cache.filter((role) => role.id !== interaction.guild.id);
     const listedRoles = filteredRoles.sort((a, b) => b.position - a.position).map((role) => role.toString());
-
-    const onlineStatus = beautifiedStatus[targetMember.presence?.status?.toUpperCase() ?? 'OFFLINE'];
-
-    let status;
-    if (targetMember.presence == null) {
-        status = 'Offline';
-    } else {
-        status = onlineStatus;
-    }
 
     const whoisEmbed = makeEmbed({
         author: {
@@ -51,11 +35,6 @@ export default slashCommand(data, async ({ interaction }) => {
             {
                 name: 'Username',
                 value: targetMember.user.tag,
-                inline: true,
-            },
-            {
-                name: 'Status',
-                value: status,
                 inline: true,
             },
             {

--- a/src/events/logging/scamLogs.ts
+++ b/src/events/logging/scamLogs.ts
@@ -179,7 +179,7 @@ export default event(Events.MessageCreate, async ({ log }, msg) => {
             const newInfraction = {
                 infractionType: 'ScamLog',
                 moderatorID: msg.client.user.id,
-                reason: `Message content: ${msg.content.toString()}`,
+                reason: 'Automatic timeout: @everyone scam detection',
                 date: new Date(),
                 infractionID: new mongoose.Types.ObjectId(),
             };


### PR DESCRIPTION
## Description

Removed the online status information from the whois command and the User Info context, it is not critical and it is the only reason we were using the Presence Intent, so we can remove this and be more privacy/security conscious. Also removed logging detailed messages off-platform for the scam logs for the same reason

## Discord Username

straks
